### PR TITLE
Update CreateRecord/Translatable.php

### DIFF
--- a/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -114,15 +114,15 @@ trait Translatable
 
         $translatableAttributes = $record->getTranslatableAttributes();
 
+        // Fill non-translatable data
         $record->fill(Arr::except(Arr::first($data), $translatableAttributes));
 
+        // Fill translatable data
         foreach ($data as $locale => $localeData) {
-            if ($locale === $this->activeLocale) {
-                $localeData = Arr::only(
-                    $localeData,
-                    app(static::getModel())->getTranslatableAttributes(),
-                );
-            }
+            $localeData = Arr::only(
+                $localeData,
+                app(static::getModel())->getTranslatableAttributes(),
+            );
 
             foreach ($localeData as $key => $value) {
                 $record->setTranslation($key, $locale, $value);


### PR DESCRIPTION
# Error Link
https://flareapp.io/share/95JwJerm

# Description
When using `mutateFormDataBeforeCreate` and we have values for different languages, the error appears.

# Steps to reproduce
1. Create a resource with translation
2. Add translatable columns to the model
3. Add some data using `mutateFormDataBeforeCreate`
4. Create new record (must fill more than one language data, so the error appears)
=> The error will appears