### PR TITLE
 fix the search in the table and now you can search with with multipl…

### DIFF
--- a/src/SpatieLaravelTranslatableContentDriver.php
+++ b/src/SpatieLaravelTranslatableContentDriver.php
@@ -110,20 +110,28 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
         return $attributes;
     }
 
-    public function applySearchConstraintToQuery(Builder $query, string $column, string $search, string $whereClause, ?bool $isCaseInsensitivityForced = null): Builder
+    public function applySearchConstraintToQuery(Builder $query, string $column, string $search, string $whereClause, bool $isCaseInsensitivityForced = false): Builder
     {
         /** @var Connection $databaseConnection */
         $databaseConnection = $query->getConnection();
-
-        $column = match ($databaseConnection->getDriverName()) {
+    
+        $columnAlias = match ($databaseConnection->getDriverName()) {
             'pgsql' => "{$column}->>'{$this->activeLocale}'",
-            default => "json_extract({$column}, \"$.{$this->activeLocale}\")",
+            default => "JSON_UNQUOTE(JSON_EXTRACT({$column}, '$.{$this->activeLocale}'))",
         };
-
-        return $query->{$whereClause}(
-            generate_search_column_expression($column, $isCaseInsensitivityForced, $databaseConnection),
-            'like',
-            (string) str($search)->wrap('%'),
-        );
+    
+        $subquery = $query->selectRaw('1')
+            ->whereRaw("$columnAlias LIKE ?", ["%{$search}%"]);
+    
+        $caseAwareSearchColumn = $isCaseInsensitivityForced ?
+            new Expression("LOWER({$column})") :
+            $column;
+    
+        return $query->{$whereClause}(function ($query) use ($subquery, $caseAwareSearchColumn, $search) {
+            $query->whereExists($subquery)
+                ->orWhere(function ($query) use ($caseAwareSearchColumn, $search) {
+                    $query->where($caseAwareSearchColumn, 'LIKE', "%{$search}%");
+                });
+        });
     }
 }


### PR DESCRIPTION
**There was error in searching in the table** 

<img width="1206" alt="لقطة شاشة 2024-01-22 172902" src="https://github.com/filamentphp/spatie-laravel-translatable-plugin/assets/94101869/bc2928fc-85ed-4e86-85f8-0f24e1fb0486">

 **i have solved.**

i edited the function applySearchConstraintToQuery in the following path src\SpatieLaravelTranslatableContentDriver.php 

--------------------------------------------
**The updated code includes several changes. Here's a breakdown of the changes made:**
The variable $column has been replaced with $columnAlias. This change is made to improve code readability and to clarify that the variable represents an alias for the column.

The match expression for the PostgreSQL driver ('pgsql') has remained the same, but the default case now uses the JSON_UNQUOTE and JSON_EXTRACT functions to extract the value from the JSON column.

Instead of directly applying the LIKE comparison to the column, a subquery is created with selectRaw('1') and whereRaw to perform the LIKE comparison. This change allows for more flexibility in constructing the query.

The variable $caseAwareSearchColumn has been updated to use the LOWER function on the column if case insensitivity is forced.

The return statement now uses a closure (function ($query)) to apply the search constraints. Inside the closure, the whereExists method is used to check if the subquery returns any results, and the orWhere method is used to perform the LIKE comparison directly on the column.