### PR TITLE
feat: add rules support for per translations

### DIFF
--- a/src/Resources/Pages/Concerns/HasTranslatableValidation.php
+++ b/src/Resources/Pages/Concerns/HasTranslatableValidation.php
@@ -2,6 +2,8 @@
 
 namespace Filament\Resources\Pages\Concerns;
 
+use Filament\Forms\Components\Contracts\HasValidationRules;
+
 trait HasTranslatableValidation
 {
     /**
@@ -9,7 +11,10 @@ trait HasTranslatableValidation
      */
     public function setLocaleByRules(string $locale): void
     {
-        $components = $this->form->getComponents();
+        $components = array_filter(
+            $this->form->getFlatComponents(),
+            fn ($component) => $component instanceof HasValidationRules
+        );
 
         foreach ($components as $component) {
             $rules = $component->getValidationRules();

--- a/src/Resources/Pages/Concerns/HasTranslatableValidation.php
+++ b/src/Resources/Pages/Concerns/HasTranslatableValidation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Filament\Resources\Pages\Concerns;
+
+trait HasTranslatableValidation
+{
+    /**
+     * Set the validation rules for the active locale.
+     */
+    public function setLocaleByRules(string $locale): void
+    {
+        $components = $this->form->getComponents();
+
+        foreach ($components as $component) {
+            $rules = $component->getValidationRules();
+            if (! empty($rules[$locale])) {
+                $component->rule($rules[$locale]);
+                break;
+            }
+        }
+    }
+}

--- a/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -4,6 +4,7 @@ namespace Filament\Resources\Pages\CreateRecord\Concerns;
 
 use Filament\Facades\Filament;
 use Filament\Resources\Concerns\HasActiveLocaleSwitcher;
+use Filament\Resources\Pages\Concerns\HasTranslatableValidation;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
@@ -12,6 +13,7 @@ use Livewire\Attributes\Locked;
 trait Translatable
 {
     use HasActiveLocaleSwitcher;
+    use HasTranslatableValidation;
 
     protected ?string $oldActiveLocale = null;
 
@@ -28,6 +30,28 @@ trait Translatable
         return static::getResource()::getTranslatableLocales();
     }
 
+    public function beforeFill()
+    {
+        /**
+         * For the rules assigned to the locales to work properly,
+         * an empty form state must be created for each local.
+         */
+        if (empty($this->otherLocaleData)) {
+            $components = $this->form->getComponents();
+            $formData = collect($components)
+                ->mapWithKeys(
+                    fn ($component) => [
+                        $component->getName() => null,
+                    ])
+                ->toArray();
+            foreach ($this->getTranslatableLocales() as $locale) {
+                $this->otherLocaleData[$locale] = [];
+
+                $this->otherLocaleData[$locale] = $formData;
+            }
+        }
+    }
+
     protected function handleRecordCreation(array $data): Model
     {
         $record = app(static::getModel());
@@ -42,7 +66,17 @@ trait Translatable
 
         $originalData = $this->data;
 
+        /**
+         * Set the data for the active locale.
+         */
+        $this->otherLocaleData[$this->activeLocale] = Arr::only($this->data, $translatableAttributes);
+
         foreach ($this->otherLocaleData as $locale => $localeData) {
+            /**
+             * Set the validation rules for the active locale.
+             */
+            $this->setLocaleByRules($locale);
+
             $this->data = [
                 ...$this->data,
                 ...$localeData,
@@ -51,7 +85,12 @@ trait Translatable
             try {
                 $this->form->validate();
             } catch (ValidationException $exception) {
-                continue;
+                /**
+                 * If the validation fails for the active locale, set the active locale
+                 */
+                $this->activeLocale = $locale;
+
+                throw $exception;
             }
 
             $localeData = $this->mutateFormDataBeforeCreate($localeData);

--- a/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -3,6 +3,7 @@
 namespace Filament\Resources\Pages\CreateRecord\Concerns;
 
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Contracts\HasValidationRules;
 use Filament\Resources\Concerns\HasActiveLocaleSwitcher;
 use Filament\Resources\Pages\Concerns\HasTranslatableValidation;
 use Illuminate\Database\Eloquent\Model;
@@ -37,12 +38,14 @@ trait Translatable
          * an empty form state must be created for each local.
          */
         if (empty($this->otherLocaleData)) {
-            $components = $this->form->getComponents();
+            $components = $this->form->getFlatComponents();
             $formData = collect($components)
+                ->filter(
+                    fn ($component) => $component instanceof HasValidationRules
+                )
                 ->mapWithKeys(
-                    fn ($component) => [
-                        $component->getName() => null,
-                    ])
+                    fn ($component) => [$component->getName() => null]
+                )
                 ->toArray();
             foreach ($this->getTranslatableLocales() as $locale) {
                 $this->otherLocaleData[$locale] = [];


### PR DESCRIPTION
Hello everyone,

This development aims to ensure that the rules defined for each locale work properly. I have added a [`setLocaleByRules`](https://github.com/filamentphp/spatie-laravel-translatable-plugin/pull/21/files#diff-241c198ab89949cbf6a055d33e0d3b1c2f90bf3b8406c1ae053b4be7f2ec3afaR10) method to the code. This method reattaches the locale-specific rules, [defined as a `Closure` type in the `rules` method](https://github.com/filamentphp/filament/blob/2f77c665f4d566b965c079fbbac68142129fbb30/packages/forms/src/Components/Concerns/CanBeValidated.php#L436), back to the component before performing form validation.

With this change, form validation for different locales can be handled dynamically.

**Example of how to use it rules**:

```php
public static function form(Form $form): Form
{
    return $form
        ->schema([
            Forms\Components\TextInput::make('name')
                ->label(__('Category Name'))
                ->helperText(__('This is the name of the category.'))
                ->rules(fn (?Category $record) => [
                    'tr' => ['required', 'string', 'max:100', Rule::unique('tags', 'name->tr')->where('type', 'category')->ignore($record?->id, 'id')],
                    'en' => ['required', 'string', 'max:100', Rule::unique('tags', 'name->en')->where('type', 'category')->ignore($record?->id, 'id')],
                ])
        ]);
}
```


Thank you.
