### PR TITLE
Make getLocaleLabelUsing usable in service provider

### DIFF
--- a/src/SpatieLaravelTranslatablePlugin.php
+++ b/src/SpatieLaravelTranslatablePlugin.php
@@ -54,9 +54,11 @@ class SpatieLaravelTranslatablePlugin implements Plugin
         return $this;
     }
 
-    public function getLocaleLabelUsing(?Closure $callback): void
+    public function getLocaleLabelUsing(?Closure $callback): static
     {
         $this->getLocaleLabelUsing = $callback;
+
+        return $this;
     }
 
     public function getLocaleLabel(string $locale, ?string $displayLocale = null): ?string


### PR DESCRIPTION
Right now we can not do the following within the panel service providers:

```php
    public function panel(Panel $panel): Panel
    {
        return $panel
            ->plugins([
                SpatieLaravelTranslatablePlugin::make()
                    ->defaultLocales(
                        array_map(
                            static fn ($locale) => type($locale)->asString(),
                            config()->array('app.locales')
                        )
                    )
                    ->getLocaleLabelUsing(fn (string $locale, ?string $displayLocale = null): ?string => $locale),
            ])
    }
```

Because `getLocaleLabelUsing` is not returning the plugin itself, which is expected by the panel `plugins()` method.
